### PR TITLE
Implementation of the LCD in main code for game score display

### DIFF
--- a/BIG_BOT/src/config.py
+++ b/BIG_BOT/src/config.py
@@ -58,5 +58,8 @@ REED_SWITCH_PIN = 26
 # Robot Configuration
 # ===================================================================
 
+DEFAULT_SCORE = 73
+"""Default score for the robot if nothing is passed as command line argument."""
+
 MAX_OBSTACLE_DURATION = 5.0  # seconds
 """Maximum duration (in seconds) of obstacle detection, after which the robot should take action."""

--- a/BIG_BOT/src/hardware/lcd.py
+++ b/BIG_BOT/src/hardware/lcd.py
@@ -9,7 +9,7 @@ from RPLCD.i2c import CharLCD
 
 class LCD:
     """
-    Class to control a LCD display using I2C.
+    Class to control a LCD 2004 (4 rows & 20 characters) display using I2C.
     """
 
     def __init__(self, address: int = 0x27):
@@ -62,8 +62,8 @@ class LCD:
         """
         if not isinstance(score, int):
             raise TypeError("LCD score must be an integer")
-        if score < 0:
-            raise ValueError("LCD score must be a non-negative integer")
+        if score < 0 or score > 120:
+            raise ValueError("LCD score must be between 0 and 120")
         self._lcd.write_string("FatBOTtommed Girls")
         self._lcd.lf()
         self._lcd.cursor_pos = (2, 0)

--- a/BIG_BOT/src/hardware/lcd.py
+++ b/BIG_BOT/src/hardware/lcd.py
@@ -1,3 +1,9 @@
+import os
+import platform
+if os.getenv("GITHUB_ACTIONS") == "true" or platform.system() == "Windows":
+    from unittest.mock import MagicMock
+    import sys
+    sys.modules["RPLCD.i2c"] = MagicMock()
 from RPLCD.i2c import CharLCD
 
 

--- a/BIG_BOT/src/hardware/lcd.py
+++ b/BIG_BOT/src/hardware/lcd.py
@@ -77,12 +77,3 @@ class LCD:
 
     def close(self) -> None:
         self._lcd.close()
-
-
-if __name__ == "__main__":
-    lcd = LCD()
-    lcd.write_line(0, "Hello, World!")
-    lcd.write_line(1, "This is a test.")
-    lcd.write_score(100)
-    lcd.clear()
-    lcd.close()

--- a/BIG_BOT/src/hardware/lcd.py
+++ b/BIG_BOT/src/hardware/lcd.py
@@ -1,0 +1,82 @@
+from RPLCD.i2c import CharLCD
+
+
+class LCD:
+    """
+    Class to control a LCD display using I2C.
+    """
+
+    def __init__(self, address: int = 0x27):
+        """
+        Control a LCD display using I2C.
+
+        Parameters:
+            `address` (int, optional): The I2C address (in hexadecimal) of the LCD. Default is 0x27.
+        """
+        self._lcd = CharLCD(i2c_expander='PCF8574', address=address, port=1, cols=20, rows=4)
+        self._lcd.clear()
+
+    def write_line(self, row: int, message: str, line_feed: bool = True, carriage_return: bool = True) -> None:
+        """
+        Write a message to a specific row of the LCD display.
+
+        Parameters:
+            `row` (int): The row number (0-3) to write the message to.
+            `message` (str): The message to display.
+            `line_feed` (bool, optional): If True, fill the rest of the line with spaces. Default is True.
+            `carriage_return` (bool, optional): If True, move the cursor to the beginning of the next line after writing the message. Default is True.
+
+        Raises:
+            `TypeError`: If the message is not a string or the row number is not an integer.
+            `ValueError`: If the row number is not between 0 and 3.
+        """
+        if not isinstance(message, str):
+            raise TypeError("LCD message must be a string")
+        if not isinstance(row, int):
+            raise TypeError("LCD row must be an integer")
+        if row < 0 or row >= 4:
+            raise ValueError("LCD row must be between 0 and 3")
+        self._lcd.cursor_pos = (row, 0)
+        self._lcd.write_string(message)
+        if line_feed:
+            self._lcd.lf()
+        if carriage_return:
+            self._lcd.cr()
+
+    def write_score(self, score: int) -> None:
+        """
+        Write the score of the game to the LCD display.
+
+        Parameters:
+            `score` (int): The score to display.
+
+        Raises:
+            `TypeError`: If the score is not an integer.
+            `ValueError`: If the score is negative.
+        """
+        if not isinstance(score, int):
+            raise TypeError("LCD score must be an integer")
+        if score < 0:
+            raise ValueError("LCD score must be a non-negative integer")
+        self._lcd.write_string("FatBOTtommed Girls")
+        self._lcd.lf()
+        self._lcd.cursor_pos = (2, 0)
+        self._lcd.write_string(f"Score: {score} points")
+
+    def clear(self) -> None:
+        """
+        Clear the display by overwriting the data with blank characters and reset the cursor position.
+        """
+        self._lcd.clear()
+
+    def close(self) -> None:
+        self._lcd.close()
+
+
+if __name__ == "__main__":
+    lcd = LCD()
+    lcd.write_line(0, "Hello, World!")
+    lcd.write_line(1, "This is a test.")
+    lcd.write_score(100)
+    lcd.clear()
+    lcd.close()

--- a/BIG_BOT/src/main.py
+++ b/BIG_BOT/src/main.py
@@ -1,12 +1,17 @@
+import argparse
 from .robot import Robot
 
 
 def main():
-    robot: Robot = Robot()
+    parser = argparse.ArgumentParser(usage="python -m BIG_BOT.src.main [-h] --score SCORE",
+                                     description="Run the robot and set the expected score displayed on the LCD.")
+    parser.add_argument("--score", type=int, required=True, help="The expected score displayed on the LCD.")
+    args = parser.parse_args()
+
+    robot: Robot = Robot(args.score)
 
     while True:
         robot.fsm.update()
-        # robot.on_event("targets_detected")
 
 
 if __name__ == "__main__":

--- a/BIG_BOT/src/robot.py
+++ b/BIG_BOT/src/robot.py
@@ -2,10 +2,12 @@ from .config import LEFT_MOTOR_FORWARD_PIN, LEFT_MOTOR_BACKWARD_PIN, LEFT_MOTOR_
 from .config import US_FRONT_RIGHT_TRIG_PIN, US_FRONT_RIGHT_ECHO_PIN, US_FRONT_LEFT_TRIG_PIN, US_FRONT_LEFT_ECHO_PIN, US_BACK_RIGHT_TRIG_PIN, US_BACK_RIGHT_ECHO_PIN, US_BACK_LEFT_TRIG_PIN, US_BACK_LEFT_ECHO_PIN
 from .config import SERVO_CHANNELS
 from .config import REED_SWITCH_PIN, CENTER_RIGHT_CLAW_NAME, CENTER_RIGHT_CLAW_ADAFRUIT_PIN
+from .config import DEFAULT_SCORE
 from .constants import USPosition
 from .fsm.FSM import RobotFSM
 from .hardware.motorsControl import MotorsControl as Motors
 from .hardware.servoControl import ServoControl
+from .hardware.lcd import LCD
 from .hardware.adafruitServoController import AdafruitServoControl
 from .hardware.ultrasonicController import UltrasonicController
 from .hardware.reedSwitch import reedSwitch
@@ -16,23 +18,26 @@ class Robot:
     Class representing the robot, including its Finite State Machine (FSM), hardware components and characteristics.
     """
 
-    def __init__(self):
+    def __init__(self, score: int = DEFAULT_SCORE):
         self.fsm = RobotFSM(self)
         self.motor = Motors(LEFT_MOTOR_FORWARD_PIN, LEFT_MOTOR_BACKWARD_PIN, LEFT_MOTOR_EN_PIN,
                             RIGHT_MOTOR_FORWARD_PIN, RIGHT_MOTOR_BACKWARD_PIN, RIGHT_MOTOR_EN_PIN)
         # self.servoControl = ServoControl([CENTER_RIGHT_CLAW_NAME], [CENTER_RIGHT_CLAW_PIN])
-        # self.servoControl = AdafruitServoControl(channels=SERVO_CHANNELS,
-                                                #  names=[CENTER_RIGHT_CLAW_NAME],
-                                                #  pins=[CENTER_RIGHT_CLAW_ADAFRUIT_PIN])
+        # self.servoControl = AdafruitServoControl(channels=SERVO_CHANNELS, names=[
+        #                                          CENTER_RIGHT_CLAW_NAME],
+        #                                          pins=[CENTER_RIGHT_CLAW_ADAFRUIT_PIN])
+        self.lcd = LCD()
         self.camera = None
         self.ultrasonicController = UltrasonicController()
         self.ultrasonicController.add_sensor(USPosition.FRONT_RIGHT, US_FRONT_RIGHT_ECHO_PIN, US_FRONT_RIGHT_TRIG_PIN)
         self.ultrasonicController.add_sensor(USPosition.FRONT_LEFT, US_FRONT_LEFT_ECHO_PIN, US_FRONT_LEFT_TRIG_PIN)
         # self.ultrasonicController.add_sensor(USPosition.BACK_RIGHT, US_BACK_RIGHT_ECHO_PIN, US_BACK_RIGHT_TRIG_PIN)
         # self.ultrasonicController.add_sensor(USPosition.BACK_LEFT, US_BACK_LEFT_ECHO_PIN, US_BACK_LEFT_TRIG_PIN)
-
-        self.__position: tuple[int, int] = (0, 0)
         # self.reedSwitch = reedSwitch(REED_SWITCH_PIN)
+
+        self.score = score
+        self.lcd.write_score(self.score)
+        self.__position: tuple[int, int] = (0, 0)
 
     @property
     def position(self):

--- a/BIG_BOT/tests/hardware/test_lcd.py
+++ b/BIG_BOT/tests/hardware/test_lcd.py
@@ -1,0 +1,43 @@
+import pytest
+from ...src.hardware.lcd import LCD
+
+
+@pytest.fixture
+def lcd() -> LCD:
+    return LCD()
+
+
+class TestLCD:
+    def test_init(self, lcd: LCD):
+        assert lcd._lcd is not None
+
+    def test_write_line_valid(self, lcd: LCD):
+        assert lcd.write_line(0, "Hello World") is None
+        assert lcd.write_line(1, "Test Message", line_feed=False) is None
+        assert lcd.write_line(2, "Another Test", carriage_return=False) is None
+        assert lcd.write_line(3, "Final Test", line_feed=False, carriage_return=False) is None
+
+    def test_write_line_invalid(self, lcd: LCD):
+        with pytest.raises(ValueError):
+            lcd.write_line(4, "Invalid Row")
+
+        with pytest.raises(TypeError):
+            lcd.write_line("0", "Invalid row type")  # type: ignore
+
+        with pytest.raises(TypeError):
+            lcd.write_line(0, 12345)  # type: ignore
+
+    def test_write_score(self, lcd: LCD):
+        with pytest.raises(TypeError):
+            lcd.write_score("100")  # type: ignore
+
+        with pytest.raises(ValueError):
+            lcd.write_score(-10)
+
+        assert lcd.write_score(100) is None
+
+    def test_clear(self, lcd: LCD):
+        assert lcd.clear() is None
+
+    def test_close(self, lcd: LCD):
+        assert lcd.close() is None

--- a/BIG_BOT/tests/hardware/test_lcd.py
+++ b/BIG_BOT/tests/hardware/test_lcd.py
@@ -34,6 +34,9 @@ class TestLCD:
         with pytest.raises(ValueError):
             lcd.write_score(-10)
 
+        with pytest.raises(ValueError):
+            lcd.write_score(150)
+
         assert lcd.write_score(100) is None
 
     def test_clear(self, lcd: LCD):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 gpiozero==2.0.1
 adafruit-circuitpython-servokit==1.3.19
+RPLCD==1.4.0
+smbus2==0.5.0
 pytest==8.3.5
 coverage==7.6.12
 pytest-cov==6.0.0


### PR DESCRIPTION
This pull request introduces addition of a new `LCD` class for controlling a 2004 LCD display used to show the estimaed score of the robot in the game, and the inclusion of tests for the new LCD functionality.

### New LCD functionality:

* [`BIG_BOT/src/hardware/lcd.py`](diffhunk://#diff-f33c562d09f665f6267561e62920f94f9168368dbcf1ca4eb7031d22dd3d54b6R1-R88): Added a new `LCD` class to control a 2004 LCD display using I2C, including methods for writing lines, displaying scores, clearing the display, and closing the connection.

### Main execution flow changes:

* [`BIG_BOT/src/main.py`](diffhunk://#diff-6fc13309dae2492275624fdda2d72decb1dab1229f09a89a5ce31299bdf0e491R1-L9): Introduced a `--score` argument that is now required to be set in CLI when running the code, which sets the expected score displayed on the LCD. It can now be run with:
    ```powershell
    python -m BIG_BOT.src.main --score 83
    ``` 

### Configuration updates:

* [`BIG_BOT/src/config.py`](diffhunk://#diff-61f3b4bfacf78c790dc0d99176c5f5356577df1eb01dea5729304ad275c83365R61-R63): Added a `DEFAULT_SCORE` constant to set a default score for the robot if no score is provided via command line arguments (As the score must be used in CLI, it is not currently used but ensure robustness of the code so it has a fallback value).

### Robot class modifications:

* [`BIG_BOT/src/robot.py`](diffhunk://#diff-69ad02b8d7386ae4b263124629e1ada59481f96086d9d752a329e228c30c692fR5-R10): Updated the `Robot` class to include an `LCD` instance and a `score` attribute, which is displayed on the LCD upon initialization.

### Testing:

* [`BIG_BOT/tests/hardware/test_lcd.py`](diffhunk://#diff-d35f83b70c7e2f24bc447067b5c454b75485db61d72ebf0e2e117f1ca17f66fbR1-R46): Added tests for the new `LCD` class, covering initialization, writing lines and scores, and handling invalid inputs.

### Result:
![20250403_192749](https://github.com/user-attachments/assets/692ff7b0-c0fa-4405-a697-8ae12e5fb44c)