### PR TITLE
Adapt motor pins to PCB

### DIFF
--- a/BIG_BOT/src/config.py
+++ b/BIG_BOT/src/config.py
@@ -15,19 +15,19 @@ I2C_DATA_PIN = 2
 I2C_CLOCK_PIN = 3
 
 ## Motor Pins ##
-LEFT_MOTOR_FORWARD_PIN = 17
-LEFT_MOTOR_BACKWARD_PIN = 27
-LEFT_MOTOR_EN_PIN = 18  # PWM
-
-RIGHT_MOTOR_FORWARD_PIN = 5
-RIGHT_MOTOR_BACKWARD_PIN = 6
-RIGHT_MOTOR_EN_PIN = 19  # PWM
-
 # Motor driver to motor connection :
 #   - OUT 1 -> Left motor red pin
 #   - OUT 2 -> Left motor black pin
 #   - OUT 3 -> Right motor red pin
 #   - OUT 4 -> Right motor black pin
+LEFT_MOTOR_FORWARD_PIN = 5
+LEFT_MOTOR_BACKWARD_PIN = 6
+LEFT_MOTOR_EN_PIN = 19  # PWM
+
+RIGHT_MOTOR_FORWARD_PIN = 17
+RIGHT_MOTOR_BACKWARD_PIN = 27
+RIGHT_MOTOR_EN_PIN = 18  # PWM
+
 
 ## Servo Claws Pins ##
 # CENTER_RIGHT_CLAW_PIN = 12


### PR DESCRIPTION
This pull request includes changes to the motor pin configurations in the `BIG_BOT/src/config.py` file. The pin assignments for the left and right motors have been swapped.

* [`BIG_BOT/src/config.py`](diffhunk://#diff-61f3b4bfacf78c790dc0d99176c5f5356577df1eb01dea5729304ad275c83365L18-R30): The new configuration sets the left motor to use pins 5, 6, and 19, and the right motor to use pins 17, 27, and 18.