### PR TITLE
Remove usage of `@override` working with Python 3.12+

### DIFF
--- a/BIG_BOT/src/fsm/states/collectStates.py
+++ b/BIG_BOT/src/fsm/states/collectStates.py
@@ -2,7 +2,7 @@ from .State import State
 from ...constants import StateEnum
 from ...config import CENTER_RIGHT_CLAW_NAME
 from ..registry import Registry
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..FSM import RobotFSM
@@ -28,15 +28,12 @@ class CollectState(State):
         if event == 'collected':
             pass
 
-    @override
     def enter(self) -> None:
         pass
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         pass
 
@@ -56,7 +53,7 @@ class OpenClawState(State):
 
     **Methods**:
         execute(): Opens the claw
-        
+
     """
 
     def __init__(self, fsm: 'RobotFSM', enum: StateEnum):
@@ -66,15 +63,12 @@ class OpenClawState(State):
         if event == 'collected':
             pass
 
-    @override
     def enter(self) -> None:
         pass
 
-    @override
     def execute(self) -> None:
         self.fsm.robot.servoControl.setAngle(CENTER_RIGHT_CLAW_NAME, 120)
 
-    @override
     def exit(self) -> None:
         pass
 
@@ -103,15 +97,12 @@ class CloseClawState(State):
         if event == 'collected':
             pass
 
-    @override
     def enter(self) -> None:
         pass
 
-    @override
     def execute(self) -> None:
         self.fsm.robot.servoControl.setAngle(CENTER_RIGHT_CLAW_NAME, 75)
 
-    @override
     def exit(self) -> None:
         pass
 
@@ -136,14 +127,11 @@ class MoveToCollectState(State):
         if event == 'on_position':
             pass
 
-    @override
     def enter(self) -> None:
         pass
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         pass

--- a/BIG_BOT/src/fsm/states/detectionStates.py
+++ b/BIG_BOT/src/fsm/states/detectionStates.py
@@ -1,5 +1,5 @@
 from .State import State
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..FSM import RobotFSM
@@ -28,15 +28,12 @@ class DetectTargetsState(State):
             return MoveState(self.fsm)
         return self
 
-    @override
     def enter(self):
         pass
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass
 
@@ -63,14 +60,11 @@ class CheckObstaclesState(State):
             return MoveState(self.fsm)
         return self
 
-    @override
     def enter(self):
         pass
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass

--- a/BIG_BOT/src/fsm/states/dropStates.py
+++ b/BIG_BOT/src/fsm/states/dropStates.py
@@ -1,6 +1,6 @@
 from .State import State
 from .detectionStates import DetectTargetsState
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..FSM import RobotFSM
@@ -14,7 +14,7 @@ class DropState(State):
     ----------
     `fsm` : RobotFSM
         The Finite State Machine (FSM) instance that the state belongs to.
-    
+
     **Methods**:
         drop(): Opens the grippers to drop the cans.
     """
@@ -27,15 +27,12 @@ class DropState(State):
             return DetectTargetsState(self.fsm)
         return self
 
-    @override
     def enter(self):
         pass
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass
 
@@ -53,7 +50,7 @@ class MoveToDrop(State):
         The Finite State Machine (FSM) instance that the state belongs to.
 
     **Methods**:
-    
+
     """
 
     def __init__(self, fsm: 'RobotFSM'):
@@ -64,14 +61,11 @@ class MoveToDrop(State):
             return DropState(self.fsm)
         return self
 
-    @override
     def enter(self):
         pass
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass

--- a/BIG_BOT/src/fsm/states/movementStates.py
+++ b/BIG_BOT/src/fsm/states/movementStates.py
@@ -4,7 +4,7 @@ from .detectionStates import DetectTargetsState
 from .State import State
 from ..registry import Registry
 from ..myTimer import MyTimer
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 import time
 
 if TYPE_CHECKING:
@@ -25,17 +25,14 @@ class IdleState(State):
     def __init__(self, fsm: 'RobotFSM', enum: StateEnum):
         super().__init__(fsm, enum)
 
-    @override
     def enter(self, **args):
         pass
 
-    @override
     def execute(self):
         # if not self.fsm.robot.reedSwitch.read():  # The reedSwitch is a button so it's 0 when not pressed and 1 when pressed
-            self.fsm.start_time = time.time()
-            self.fsm.start_match = True
+        self.fsm.start_time = time.time()
+        self.fsm.start_match = True
 
-    @override
     def exit(self):
         print("Exiting Idle State - Match Started")
 
@@ -63,7 +60,6 @@ class MoveForwardState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args):
         self.distance = args.get('distance', self.distance)
         self.speed = args.get('speed', self.speed)
@@ -75,11 +71,9 @@ class MoveForwardState(State):
 
         self.fsm.timer = MyTimer(time_needed, self.increment_step)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -109,7 +103,6 @@ class MoveBackwardState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args):
         self.distance = args.get('distance', self.distance)
         self.speed = args.get('speed', self.speed)
@@ -121,15 +114,14 @@ class MoveBackwardState(State):
 
         self.fsm.timer = MyTimer(time_needed, self.increment_step)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         if self.fsm.timer:
             self.fsm.timer.cancel()
             self.fsm.timer = None
+
 
 @Registry.register_state(StateEnum.ROTATE_LEFT)
 class RotateLeftState(State):
@@ -156,11 +148,10 @@ class RotateLeftState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args):
         self.degrees = args.get('degrees', self.degrees)
         self.speed = args.get('speed', self.speed)
-        
+
         time_needed = self.fsm.robot.motor.rotateLeftDegrees(degrees=self.degrees, speed=self.speed)
 
         if self.fsm.timer:
@@ -169,16 +160,15 @@ class RotateLeftState(State):
 
         self.fsm.timer = MyTimer(time_needed, self.increment_step)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         if self.fsm.timer:
             self.fsm.timer.cancel()
             self.fsm.timer = None
-    
+
+
 @Registry.register_state(StateEnum.ROTATE_RIGHT)
 class RotateRightState(State):
     """
@@ -203,11 +193,10 @@ class RotateRightState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args):
         self.degrees = args.get('degrees', self.degrees)
         self.speed = args.get('speed', self.speed)
-        
+
         time_needed = self.fsm.robot.motor.rotateRightDegrees(degrees=self.degrees, speed=self.speed)
 
         if self.fsm.timer:
@@ -216,15 +205,14 @@ class RotateRightState(State):
 
         self.fsm.timer = MyTimer(time_needed, self.increment_step)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         if self.fsm.timer:
             self.fsm.timer.cancel()
             self.fsm.timer = None
+
 
 @Registry.register_state(StateEnum.AVOID_OBSTACLE)
 class AvoidObstacleState(State):
@@ -241,13 +229,11 @@ class AvoidObstacleState(State):
         super().__init__(fsm, enum)
         self._obstacle_start_time: float = 0.0
 
-    @override
     def enter(self, **args):
         print("Entering Avoid Obstacle State")
         self._obstacle_start_time = time.time()
         self.fsm.robot.motor.stop()
 
-    @override
     def execute(self):
         obstacle_duration: float = time.time() - self._obstacle_start_time
         if obstacle_duration >= MAX_OBSTACLE_DURATION and obstacle_duration < MAX_OBSTACLE_DURATION + 2.0:
@@ -256,7 +242,6 @@ class AvoidObstacleState(State):
             self.fsm.robot.motor.stop()
             self._obstacle_start_time = time.time()
 
-    @override
     def exit(self):
         pass
 
@@ -279,7 +264,6 @@ class StopState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args):
         print("Entering Stop State")
         self.fsm.robot.motor.stop()
@@ -287,11 +271,9 @@ class StopState(State):
         stopTime = args.get('stopTime', 0.1)
         self.fsm.timer = MyTimer(stopTime, self.increment_step)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         print("Exiting Stop State")
         print(self.fsm.step)
@@ -315,15 +297,12 @@ class SlowMoveState(State):
     def __init__(self, fsm: 'RobotFSM', enum: StateEnum):
         super().__init__(fsm, enum)
 
-    @override
     def enter(self, **args):
         self.fsm.robot.motor.forward(0.3)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass
 
@@ -345,15 +324,12 @@ class SlowRotateState(State):
     def __init__(self, fsm):
         super().__init__(fsm)
 
-    @override
     def enter(self, **args):
         pass
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         pass
 
@@ -363,16 +339,13 @@ class FastMoveState(State):
     def __init__(self, fsm: 'RobotFSM', enum: StateEnum):
         super().__init__(fsm, enum)
 
-    @override
     def enter(self, **args):
         distance = args.get('distance', 0.0)
         speed = args.get('speed', 1.0)
         self.fsm.robot.motor.moveForward(distance_cm=distance, speed=speed)
 
-    @override
     def execute(self):
         pass
 
-    @override
     def exit(self):
         return DetectTargetsState(self.fsm)

--- a/BIG_BOT/src/fsm/states/servoStates.py
+++ b/BIG_BOT/src/fsm/states/servoStates.py
@@ -4,7 +4,7 @@ from ...config import CENTER_RIGHT_CLAW_NAME, CENTER_LEFT_CLAW_NAME, OUTER_RIGHT
 from ...config import PLANK_PUSHER_RIGHT_NAME, PLANK_PUSHER_LEFT_NAME, HINGE_NAME, BANNER_DEPLOYER_NAME
 from ..registry import Registry
 from ..myTimer import MyTimer
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..FSM import RobotFSM
@@ -32,7 +32,6 @@ class OpenCentralClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -45,11 +44,9 @@ class OpenCentralClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -78,7 +75,6 @@ class CloseCentralClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -91,11 +87,9 @@ class CloseCentralClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -124,7 +118,6 @@ class OpenOuterClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -137,11 +130,9 @@ class OpenOuterClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -170,7 +161,6 @@ class CloseOuterClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -183,11 +173,9 @@ class CloseOuterClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -216,7 +204,6 @@ class DeployPankPushersState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -229,11 +216,9 @@ class DeployPankPushersState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -262,7 +247,6 @@ class DeployPankPushersState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -275,11 +259,9 @@ class DeployPankPushersState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -308,7 +290,6 @@ class DeployClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -320,11 +301,9 @@ class DeployClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -353,7 +332,6 @@ class DeployClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -365,16 +343,13 @@ class DeployClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
             self.fsm.timer = None
-
 
 
 @Registry.register_state(StateEnum.DEPLOY_CLAWS)
@@ -399,7 +374,6 @@ class DeployClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -411,11 +385,9 @@ class DeployClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
@@ -444,7 +416,6 @@ class RetractClawsState(State):
         if self.fsm.step < self.fsm.maxStep:
             self.fsm.step += 1
 
-    @override
     def enter(self, **args) -> None:
         self.angle = args.get('angle', self.angle)
 
@@ -456,14 +427,10 @@ class RetractClawsState(State):
 
         self.fsm.timer = MyTimer(0.5, self.increment_step)
 
-    @override
     def execute(self) -> None:
         pass
 
-    @override
     def exit(self) -> None:
         if self.fsm.timer:
             self.fsm.timer.cancel()
             self.fsm.timer = None
-
-


### PR DESCRIPTION
The `@override` decorator was introduced in Python 3.12 and therefore does not work on Raspberry Pi 4 built-in python 3.11.
It has therefore been removed and do not cause any problems because the `State` is an interface implementing the `ABC` abstract base class, and raising `NotImplementedError` if we try to use or we do not override the interface methods.