### PR TITLE
Hotfix toggle ultrasonic sensors command

### DIFF
--- a/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
+++ b/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
@@ -39,27 +39,21 @@ class ToggleUltrasonicSensorsCommand(ICommand):
 class  DisableUltrasonicSensorsCommand(ICommand):
     def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
         self.fsm = fsm
-        self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions
 
     def execute(self):
-        for i in range(len(self.positions)):
-            self.fsm.robot.ultrasonicController.disable_sensor(self.positions[i])
+        for position in self.positions:
+            self.fsm.robot.ultrasonicController.disable_sensor(position)
+
+
 
     def pause(self):
         pass  # No action needed for pause
 
     def resume(self):
-        current_states = self.fsm.robot.ultrasonicController.get_enabled_sensors()
-    
         for position in self.positions:
-            # Check if the current state is different from the initial state
-            current_state = current_states[position]
-            initial_state = self.initialStates[position]
+            self.fsm.robot.ultrasonicController.disable_sensor(position)
 
-            if current_state == initial_state:
-                # Toggle the neeeded sensor to the opposite state
-                self.fsm.robot.ultrasonicController.toggle_sensor(position)
 
     def stop(self):
         pass  # No action needed for stop
@@ -70,27 +64,21 @@ class  DisableUltrasonicSensorsCommand(ICommand):
 class EnableUltrasonicSensorsCommand(ICommand):
     def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
         self.fsm = fsm
-        self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions
 
     def execute(self):
-        for i in range(len(self.positions)):
-            self.fsm.robot.ultrasonicController.enable_sensor(self.positions[i])
+        for position in self.positions:
+            self.fsm.robot.ultrasonicController.enable_sensor(position)
+
+
 
     def pause(self):
         pass  # No action needed for pause
 
     def resume(self):
-        current_states = self.fsm.robot.ultrasonicController.get_enabled_sensors()
-    
         for position in self.positions:
-            # Check if the current state is different from the initial state
-            current_state = current_states[position]
-            initial_state = self.initialStates[position]
+            self.fsm.robot.ultrasonicController.enable_sensor(position)
 
-            if current_state == initial_state:
-                # Toggle the neeeded sensor to the opposite state
-                self.fsm.robot.ultrasonicController.toggle_sensor(position)
 
     def stop(self):
         pass  # No action needed for stop

--- a/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
+++ b/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from ..FSM import RobotFSM
 
 class ToggleUltrasonicSensorsCommand(ICommand):
-    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
         self.fsm = fsm
         self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions
@@ -35,3 +35,66 @@ class ToggleUltrasonicSensorsCommand(ICommand):
 
     def finished(self):
         pass  # No action needed for finished
+
+class  DisableUltrasonicSensorsCommand(ICommand):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
+        self.fsm = fsm
+        self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
+        self.positions = positions
+
+    def execute(self):
+        for i in range(len(self.positions)):
+            self.fsm.robot.ultrasonicController.disable_sensor(self.positions[i])
+
+    def pause(self):
+        pass  # No action needed for pause
+
+    def resume(self):
+        current_states = self.fsm.robot.ultrasonicController.get_enabled_sensors()
+    
+        for position in self.positions:
+            # Check if the current state is different from the initial state
+            current_state = current_states[position]
+            initial_state = self.initialStates[position]
+
+            if current_state == initial_state:
+                # Toggle the neeeded sensor to the opposite state
+                self.fsm.robot.ultrasonicController.toggle_sensor(position)
+
+    def stop(self):
+        pass  # No action needed for stop
+
+    def finished(self):
+        pass  # No action needed for finished
+
+class EnableUltrasonicSensorsCommand(ICommand):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
+        self.fsm = fsm
+        self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
+        self.positions = positions
+
+    def execute(self):
+        for i in range(len(self.positions)):
+            self.fsm.robot.ultrasonicController.enable_sensor(self.positions[i])
+
+    def pause(self):
+        pass  # No action needed for pause
+
+    def resume(self):
+        current_states = self.fsm.robot.ultrasonicController.get_enabled_sensors()
+    
+        for position in self.positions:
+            # Check if the current state is different from the initial state
+            current_state = current_states[position]
+            initial_state = self.initialStates[position]
+
+            if current_state == initial_state:
+                # Toggle the neeeded sensor to the opposite state
+                self.fsm.robot.ultrasonicController.toggle_sensor(position)
+
+    def stop(self):
+        pass  # No action needed for stop
+
+    def finished(self):
+        pass  # No action needed for finished
+

--- a/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
+++ b/BIG_BOT/src/fsm/commands/ultrasonicCommands.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from ..FSM import RobotFSM
 
 class ToggleUltrasonicSensorsCommand(ICommand):
-    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
         self.fsm = fsm
         self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions
@@ -37,7 +37,7 @@ class ToggleUltrasonicSensorsCommand(ICommand):
         pass  # No action needed for finished
 
 class  DisableUltrasonicSensorsCommand(ICommand):
-    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
         self.fsm = fsm
         self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions
@@ -68,7 +68,7 @@ class  DisableUltrasonicSensorsCommand(ICommand):
         pass  # No action needed for finished
 
 class EnableUltrasonicSensorsCommand(ICommand):
-    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition],):
+    def __init__(self, fsm: 'RobotFSM', positions: list[USPosition]):
         self.fsm = fsm
         self.initialStates = fsm.robot.ultrasonicController.get_enabled_sensors()
         self.positions = positions


### PR DESCRIPTION
This pull request introduces two new command classes to manage the ultrasonic sensors in the robot's finite state machine (FSM). These classes allow for enabling and disabling ultrasonic sensors, as well as handling their states during execution, pause, resume, stop, and finish actions. This is needed for code readability, as we might get lost after multiple toggles if only toggles are used. 

New command classes for ultrasonic sensors:

* [`BIG_BOT/src/fsm/commands/ultrasonicCommands.py`](diffhunk://#diff-8c2bcd48fff50a33a41a1c1521955132f440488c6fad37792cda4a7d78832057R38-R100): Added `DisableUltrasonicSensorsCommand` class to disable specified ultrasonic sensors and manage their states.
* [`BIG_BOT/src/fsm/commands/ultrasonicCommands.py`](diffhunk://#diff-8c2bcd48fff50a33a41a1c1521955132f440488c6fad37792cda4a7d78832057R38-R100): Added `EnableUltrasonicSensorsCommand` class to enable specified ultrasonic sensors and manage their states.