### PR TITLE
Add link to project wiki in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Project management, task sharing, autonomy, team spirit and experimentation are 
 
 The Belgian competition was held in **Mons** and hosted by **[SparkOH!](https://sparkoh.be/projet-robotixs/robotixs/)** on April 19-20, 2025.
 
+Have a look at our **[Wiki](https://github.com/NJurquet/FBG/wiki)** for more details about the project, team, robots, and strategy.
+
 ### Theme
 
 The 2025 theme is **The Show Must Go On!**:


### PR DESCRIPTION
This pull request introduces a small update to the `README.md` file by adding a link to the project's Wiki for more detailed information about the project, team, robots, and strategy, so we are sure that the project documentation is easily visible and accessible.