### PR TITLE
Include python coverage in README

### DIFF
--- a/.github/workflows/big_bot_tests.yml
+++ b/.github/workflows/big_bot_tests.yml
@@ -19,7 +19,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -30,4 +30,9 @@ jobs:
 
             - name: Run tests with pytest
               run: |
-                  pytest BIG_BOT/tests
+                  pytest BIG_BOT/tests --cov --cov-branch --cov-report=xml
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fat BOTtomed Girls (FBG) - 2025 Eurobot Project
 
 [![Tests for Big Bot](https://github.com/NJurquet/FBG/actions/workflows/big_bot_tests.yml/badge.svg)](https://github.com/NJurquet/FBG/actions/workflows/big_bot_tests.yml)
+[![codecov](https://codecov.io/gh/NJurquet/FBG/graph/badge.svg?token=ZNFK9L2G5Q)](https://codecov.io/gh/NJurquet/FBG)
 
 ## Overview
 


### PR DESCRIPTION
This pull request updates the CI workflow to improve test coverage reporting and integrates Codecov for coverage tracking. Additionally, it updates the project documentation to reflect these changes.

### CI Workflow Improvements:
* [`.github/workflows/big_bot_tests.yml`](diffhunk://#diff-7db6c788ac724d273a037536ff4cbf265558fc7bc2aed5b53560238b73212518L22-R22): Updated `actions/setup-python` to version `v4` for better compatibility and features.
* [`.github/workflows/big_bot_tests.yml`](diffhunk://#diff-7db6c788ac724d273a037536ff4cbf265558fc7bc2aed5b53560238b73212518L33-R38): Enhanced pytest command to include coverage reporting (`--cov`, `--cov-branch`, `--cov-report=xml`) and added a step to upload coverage reports to Codecov using `codecov/codecov-action@v5`.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4): Added a Codecov badge to display test coverage status directly in the project README.